### PR TITLE
remove CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.birchpath.love


### PR DESCRIPTION
should set CNAME in DNS config
this CNAME file makes the github page redirect to
`www.birchpath.love`, which the browser then looks to DNS for.  Since
it's not configured in DNS, it fails
